### PR TITLE
Block entities using NMS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           git config --global user.email "no-reply@github.com"
           git config --global user.name "Github Actions"
-          ./gradlew applyPatches --stacktrace
+          ./gradlew applyAllPatches --stacktrace
 
       - name: Build
         run: ./gradlew build --stacktrace

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ You are very welcome to help with implementation, testing, sharing knowledge or 
 Fiddle is a drop-in replacement for Paper.
 
 There are no builds available at the moment, but you can build Fiddle yourself by cloning the project and doing:
-* `./gradlew applyPatches`
+* `./gradlew applyAllPatches`
 * Create a runnable server jar with `./gradlew createMojmapPaperclipJar` (the jar file will be placed in `fiddle-server/build/libs`)
 
 You can easily run a test server (which [includes some example blocks and items](https://github.com/FiddleMC/Fiddle/blob/master/test-plugin/src/main/java/org/fiddlemc/testplugin/TestPluginBootstrap.java)):
-* `./gradlew applyPatches`
+* `./gradlew applyAllPatches`
 * `./gradlew runDevServer`
 <!--
 You can download the latest stable JAR from [releases](https://github.com/FiddleMC/Fiddle/releases) and the latest development JAR from [actions](https://github.com/FiddleMC/Fiddle/actions).

--- a/fiddle-api/paper-patches/files/src/main/java/io/papermc/paper/registry/RegistryKey.java.patch
+++ b/fiddle-api/paper-patches/files/src/main/java/io/papermc/paper/registry/RegistryKey.java.patch
@@ -1,15 +1,16 @@
 --- a/src/main/java/io/papermc/paper/registry/RegistryKey.java
 +++ b/src/main/java/io/papermc/paper/registry/RegistryKey.java
-@@ -39,6 +_,8 @@
+@@ -39,6 +_,9 @@
  import org.bukkit.map.MapCursor;
  import org.bukkit.potion.PotionEffectType;
  import org.bukkit.potion.PotionType;
++import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.BlockEntityType;
 +import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.FiddleBlockType;
 +import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.FiddleItemType;
  import org.jspecify.annotations.NullMarked;
  
  import static io.papermc.paper.registry.RegistryKeyImpl.create;
-@@ -77,6 +_,16 @@
+@@ -77,6 +_,20 @@
       * @see io.papermc.paper.registry.keys.MobEffectKeys
       */
      RegistryKey<PotionEffectType> MOB_EFFECT = create("mob_effect");
@@ -22,6 +23,10 @@
 +     * Built-in registry for Fiddle item types.
 +     */
 +    RegistryKey<FiddleItemType> FIDDLE_ITEM_TYPE = create("fiddle:item_type");
++    /**
++     * Built-in registry for block entity types.
++     */
++    RegistryKey<BlockEntityType> BLOCK_ENTITY_TYPE = create("block_entity_type");
 +    // Fiddle end - More data-driven - Paper registry API - Types - API part - Define registry keys
      /**
       * Built-in registry for block types.

--- a/fiddle-api/paper-patches/files/src/main/java/io/papermc/paper/registry/event/RegistryEvents.java.patch
+++ b/fiddle-api/paper-patches/files/src/main/java/io/papermc/paper/registry/event/RegistryEvents.java.patch
@@ -1,6 +1,6 @@
 --- a/src/main/java/io/papermc/paper/registry/event/RegistryEvents.java
 +++ b/src/main/java/io/papermc/paper/registry/event/RegistryEvents.java
-@@ -57,6 +_,14 @@
+@@ -57,6 +_,15 @@
      public static final RegistryEventProvider<ZombieNautilus.Variant, ZombieNautilusVariantRegistryEntry.Builder> ZOMBIE_NAUTILUS_VARIANT = create(RegistryKey.ZOMBIE_NAUTILUS_VARIANT);
      public static final RegistryEventProvider<Dialog, DialogRegistryEntry.Builder> DIALOG = create(RegistryKey.DIALOG);
      // End generate - RegistryEvents
@@ -11,6 +11,7 @@
 +    // Fiddle start - More data-driven - Paper registry API - API part - Add event providers
 +    public static final RegistryEventProvider<org.bukkit.block.BlockType, org.fiddlemc.fiddle.api.moredatadriven.paper.registry.BlockRegistryEntry.Builder> BLOCK = RegistryEventProviderImpl.create(RegistryKey.BLOCK);
 +    public static final RegistryEventProvider<org.bukkit.inventory.ItemType, org.fiddlemc.fiddle.api.moredatadriven.paper.registry.ItemRegistryEntry.Builder> ITEM = RegistryEventProviderImpl.create(RegistryKey.ITEM);
++    public static final RegistryEventProvider<org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.BlockEntityType, org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.BlockEntityTypeRegistryEntry.Builder> BLOCK_ENTITY_TYPE = RegistryEventProviderImpl.create(RegistryKey.BLOCK_ENTITY_TYPE);
 +    // Fiddle end - More data-driven - Paper registry API - API part - Add event providers
  
      private RegistryEvents() {

--- a/fiddle-api/src/main/java/org/fiddlemc/fiddle/api/FiddleEvents.java
+++ b/fiddle-api/src/main/java/org/fiddlemc/fiddle/api/FiddleEvents.java
@@ -13,6 +13,8 @@ import org.fiddlemc.fiddle.api.bukkit.enuminjection.BukkitEnumNamesComposeEvent;
 import org.fiddlemc.fiddle.api.bukkit.enuminjection.material.MaterialEnumNames;
 import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.BlockRegistryEntry;
 import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.ItemRegistryEntry;
+import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.BlockEntityType;
+import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.BlockEntityTypeRegistryEntry;
 import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.FiddleBlockTypeRegistryEntry;
 import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.FiddleItemTypeRegistryEntry;
 import org.fiddlemc.fiddle.api.packetmapping.block.BlockMappings;
@@ -43,6 +45,7 @@ public final class FiddleEvents {
     public static final LifecycleEventType.Prioritizable<BootstrapContext, RegistryComposeEvent<?, FiddleItemTypeRegistryEntry.Builder>> ITEM_TYPE = (LifecycleEventType.Prioritizable) RegistryEvents.ITEM_TYPE.compose();
     public static final LifecycleEventType.Prioritizable<BootstrapContext, RegistryComposeEvent<BlockType, BlockRegistryEntry.Builder>> BLOCK = RegistryEvents.BLOCK.compose();
     public static final LifecycleEventType.Prioritizable<BootstrapContext, RegistryComposeEvent<ItemType, ItemRegistryEntry.Builder>> ITEM = RegistryEvents.ITEM.compose();
+    public static final LifecycleEventType.Prioritizable<BootstrapContext, RegistryComposeEvent<BlockEntityType, BlockEntityTypeRegistryEntry.Builder>> BLOCK_ENTITY_TYPE = RegistryEvents.BLOCK_ENTITY_TYPE.compose();
     public static final ComposableEventType<FiddleResourcePackConstructEvent> RESOURCE_PACK_CONSTRUCT = FiddleResourcePackConstruction.get().compose();
     public static final LifecycleEventType<BootstrapContext, FiddleResourcePackConstructFinishEvent, PrioritizedLifecycleEventHandlerConfiguration<BootstrapContext>> RESOURCE_PACK_CONSTRUCT_FINISH = FiddleResourcePackConstruction.get().finish();
     public static final ComposableEventType<BlockMappingsComposeEvent<?>> BLOCK_MAPPING = ((BlockMappings) BlockMappings.get()).compose();

--- a/fiddle-api/src/main/java/org/fiddlemc/fiddle/api/moredatadriven/paper/registry/type/BlockEntityType.java
+++ b/fiddle-api/src/main/java/org/fiddlemc/fiddle/api/moredatadriven/paper/registry/type/BlockEntityType.java
@@ -1,0 +1,6 @@
+package org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type;
+
+import org.bukkit.Keyed;
+
+public interface BlockEntityType extends Keyed {
+}

--- a/fiddle-api/src/main/java/org/fiddlemc/fiddle/api/moredatadriven/paper/registry/type/BlockEntityType.java
+++ b/fiddle-api/src/main/java/org/fiddlemc/fiddle/api/moredatadriven/paper/registry/type/BlockEntityType.java
@@ -2,5 +2,8 @@ package org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type;
 
 import org.bukkit.Keyed;
 
+/**
+ * A type of block entity.
+ */
 public interface BlockEntityType extends Keyed {
 }

--- a/fiddle-api/src/main/java/org/fiddlemc/fiddle/api/moredatadriven/paper/registry/type/BlockEntityTypeRegistryEntry.java
+++ b/fiddle-api/src/main/java/org/fiddlemc/fiddle/api/moredatadriven/paper/registry/type/BlockEntityTypeRegistryEntry.java
@@ -1,10 +1,40 @@
 package org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type;
 
 import io.papermc.paper.registry.RegistryBuilder;
+import org.bukkit.block.BlockType;
+import org.jetbrains.annotations.ApiStatus;
 
+/**
+ * A data-centric version-specific registry entry for the {@link BlockEntityType} type.
+ */
+@ApiStatus.Experimental
+@ApiStatus.NonExtendable
 public interface BlockEntityTypeRegistryEntry {
 
+    /**
+     * A mutable builder for the {@link BlockEntityTypeRegistryEntry},
+     * that plugins may change in applicable registry events.
+      * <p>
+     * Currently, this must be cast to {@code BlockEntityTypeRegistryEntryBuilderNMS} to be used.
+     * </p>
+     * <p>
+     * It is mandatory to assign a factory. (Currently only possible using NMS)
+     * </p>
+     */
+    @ApiStatus.Experimental
+    @ApiStatus.NonExtendable
     interface Builder extends RegistryBuilder<BlockEntityType> {
-
+        /**
+         * Add block types that are valid for this block entity type.
+         *
+         * <p>
+         * For example, the shulker box block entity type would be valid for all the
+         * different colors of shulker box blocks.
+         * </p>
+         *
+         * @param blocks The block types.
+         * @return This builder, for chaining.
+         */
+        Builder validBlocks(BlockType... blocks);
     }
 }

--- a/fiddle-api/src/main/java/org/fiddlemc/fiddle/api/moredatadriven/paper/registry/type/BlockEntityTypeRegistryEntry.java
+++ b/fiddle-api/src/main/java/org/fiddlemc/fiddle/api/moredatadriven/paper/registry/type/BlockEntityTypeRegistryEntry.java
@@ -1,0 +1,10 @@
+package org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type;
+
+import io.papermc.paper.registry.RegistryBuilder;
+
+public interface BlockEntityTypeRegistryEntry {
+
+    interface Builder extends RegistryBuilder<BlockEntityType> {
+
+    }
+}

--- a/fiddle-server/minecraft-patches/sources/net/minecraft/core/registries/BuiltInRegistries.java.patch
+++ b/fiddle-server/minecraft-patches/sources/net/minecraft/core/registries/BuiltInRegistries.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/core/registries/BuiltInRegistries.java
 +++ b/net/minecraft/core/registries/BuiltInRegistries.java
-@@ -172,12 +_,12 @@
+@@ -172,16 +_,25 @@
      public static final Registry<SoundEvent> SOUND_EVENT = registerSimple(Registries.SOUND_EVENT, registry -> SoundEvents.ITEM_PICKUP);
      public static final DefaultedRegistry<Fluid> FLUID = registerDefaultedWithIntrusiveHolders(Registries.FLUID, "empty", registry -> Fluids.EMPTY);
      public static final Registry<MobEffect> MOB_EFFECT = registerSimple(Registries.MOB_EFFECT, MobEffects::bootstrap);
@@ -14,14 +14,29 @@
 +    public static final org.fiddlemc.fiddle.impl.moredatadriven.minecraft.ItemRegistry ITEM = internalRegister(Registries.ITEM, org.fiddlemc.fiddle.impl.moredatadriven.minecraft.ItemRegistry.get(), registry -> Items.AIR); // Fiddle - More data-driven - Minecraft registries - Use custom class
      public static final Registry<Potion> POTION = registerSimple(Registries.POTION, Potions::bootstrap);
      public static final Registry<ParticleType<?>> PARTICLE_TYPE = registerSimple(Registries.PARTICLE_TYPE, registry -> ParticleTypes.BLOCK);
-     public static final Registry<BlockEntityType<?>> BLOCK_ENTITY_TYPE = registerSimpleWithIntrusiveHolders(
+-    public static final Registry<BlockEntityType<?>> BLOCK_ENTITY_TYPE = registerSimpleWithIntrusiveHolders(
+-        Registries.BLOCK_ENTITY_TYPE, registry -> BlockEntityType.FURNACE
++    // Fiddle start - More data-driven - Block entities - Use delayed freezing
++    public static final Registry<BlockEntityType<?>> BLOCK_ENTITY_TYPE = internalRegister(
++        Registries.BLOCK_ENTITY_TYPE,
++        new MappedRegistry<>(Registries.BLOCK_ENTITY_TYPE, Lifecycle.stable(), true) {
++            @Override
++            public boolean isFreezingDelayed() {
++                return true;
++            }
++        },
++        registry -> BlockEntityType.FURNACE
++    // Fiddle end - More data-driven - Block entities - Use delayed freezing
+     );
+     public static final Registry<Identifier> CUSTOM_STAT = registerSimple(Registries.CUSTOM_STAT, registry -> Stats.JUMP);
+     public static final DefaultedRegistry<ChunkStatus> CHUNK_STATUS = registerDefaulted(Registries.CHUNK_STATUS, "empty", registry -> ChunkStatus.EMPTY);
 @@ -278,7 +_,8 @@
      public static final Registry<MapCodec<? extends DensityFunction>> DENSITY_FUNCTION_TYPE = registerSimple(
          Registries.DENSITY_FUNCTION_TYPE, DensityFunctions::bootstrap
      );
 -    public static final Registry<MapCodec<? extends Block>> BLOCK_TYPE = registerSimple(Registries.BLOCK_TYPE, BlockTypes::bootstrap);
-+    public static final Registry<org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.nms.WrappedBlockCodec<?>> FIDDLE_BLOCK_TYPE = registerSimple(Registries.FIDDLE_BLOCK_TYPE, BlockTypes::bootstrap); // Fiddle - More data-driven - Minecraft registries - Types - Adapt existing block type registry
-+    public static final Registry<org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.nms.WrappedItemCodec<?>> FIDDLE_ITEM_TYPE = registerSimple(Registries.FIDDLE_ITEM_TYPE, org.fiddlemc.fiddle.impl.moredatadriven.minecraft.type.ItemTypes::bootstrap); // Fiddle - More data-driven - Minecraft registries - Types - Add item type registry
++    public static final Registry<org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.nms.WrappedBlockCodec<?>> FIDDLE_BLOCK_TYPE = BuiltInRegistries.<org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.nms.WrappedBlockCodec<?>>registerSimple(Registries.FIDDLE_BLOCK_TYPE, BlockTypes::bootstrap); // Fiddle - More data-driven - Minecraft registries - Types - Adapt existing block type registry
++    public static final Registry<org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.nms.WrappedItemCodec<?>> FIDDLE_ITEM_TYPE = BuiltInRegistries.<org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.nms.WrappedItemCodec<?>>registerSimple(Registries.FIDDLE_ITEM_TYPE, org.fiddlemc.fiddle.impl.moredatadriven.minecraft.type.ItemTypes::bootstrap); // Fiddle - More data-driven - Minecraft registries - Types - Add item type registry
      public static final Registry<StructureProcessorType<?>> STRUCTURE_PROCESSOR = registerSimple(
          Registries.STRUCTURE_PROCESSOR, registry -> StructureProcessorType.BLOCK_IGNORE
      );

--- a/fiddle-server/minecraft-patches/sources/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java.patch
+++ b/fiddle-server/minecraft-patches/sources/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java
++++ b/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java
+@@ -28,6 +_,7 @@
+     private final CompoundTag tag;
+ 
+     public static ClientboundBlockEntityDataPacket create(BlockEntity blockEntity, BiFunction<BlockEntity, RegistryAccess, CompoundTag> dataGetter) {
++        if (!blockEntity.getType().isVanilla()) return null; // Fiddle - More data-driven - Block entities - Don't send non-vanilla block entities to the client
+         RegistryAccess registryAccess = blockEntity.getLevel().registryAccess();
+         return new ClientboundBlockEntityDataPacket(blockEntity.getBlockPos(), blockEntity.getType(), blockEntity.sanitizeSentNbt(dataGetter.apply(blockEntity, registryAccess))); // Paper - Sanitize sent data
+     }

--- a/fiddle-server/minecraft-patches/sources/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java.patch
+++ b/fiddle-server/minecraft-patches/sources/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java.patch
@@ -18,6 +18,14 @@
          // Paper start - Anti-Xray - Add chunk packet info
          if (chunkPacketInfo != null) {
              chunkPacketInfo.setBuffer(this.buffer);
+@@ -62,6 +_,7 @@
+         int totalTileEntities = 0; // Paper - Handle oversized block entities in chunks
+ 
+         for (Entry<BlockPos, BlockEntity> entry : levelChunk.getBlockEntities().entrySet()) {
++            if (!entry.getValue().getType().isVanilla()) return; // Fiddle - More data-driven - Block entities - Don't send non-vanilla block entities to the client
+             // Paper start - Handle oversized block entities in chunks
+             if (++totalTileEntities > BLOCK_ENTITY_LIMIT) {
+                 net.minecraft.network.protocol.Packet<ClientGamePacketListener> packet = entry.getValue().getUpdatePacket();
 @@ -82,6 +_,7 @@
              throw new RuntimeException("Chunk Packet trying to allocate too much memory on read.");
          } else {

--- a/fiddle-server/minecraft-patches/sources/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
+++ b/fiddle-server/minecraft-patches/sources/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
@@ -1,7 +1,44 @@
 --- a/net/minecraft/world/level/block/entity/BlockEntityType.java
 +++ b/net/minecraft/world/level/block/entity/BlockEntityType.java
-@@ -292,7 +_,7 @@
-         return Registry.register(BuiltInRegistries.BLOCK_ENTITY_TYPE, name, new BlockEntityType<>(factory, Set.of(validBlocks)));
+@@ -277,6 +_,32 @@
+     public final Set<Block> validBlocks;
+     private final Holder.Reference<BlockEntityType<?>> builtInRegistryHolder = BuiltInRegistries.BLOCK_ENTITY_TYPE.createIntrusiveHolder(this);
+ 
++    // Fiddle start - More data-driven - Vanilla flag - Implementation part
++    private boolean isVanilla;
++
++    /**
++     * Returns whether this block entity type is present in vanilla.
++     * @return Whether this block is present in vanilla.
++     */
++    public boolean isVanilla() {
++        return this.isVanilla;
++    }
++
++    /**
++     * Sets {@link #isVanilla} to true.
++     *
++     * <p>
++     * This must only be called at most once,
++     * before the block is registered to {@link BuiltInRegistries#BLOCK_ENTITY_TYPE}.
++     * </p>
++     * @return this.
++     */
++    private BlockEntityType<T> markAsVanilla() {
++        this.isVanilla = true;
++        return this;
++    }
++    // Fiddle end - More data-driven - Vanilla flag - Implementation part
++
+     public static @Nullable Identifier getKey(BlockEntityType<?> type) {
+         return BuiltInRegistries.BLOCK_ENTITY_TYPE.getKey(type);
+     }
+@@ -289,10 +_,10 @@
+         }
+ 
+         Util.fetchChoiceType(References.BLOCK_ENTITY, name);
+-        return Registry.register(BuiltInRegistries.BLOCK_ENTITY_TYPE, name, new BlockEntityType<>(factory, Set.of(validBlocks)));
++        return Registry.register(BuiltInRegistries.BLOCK_ENTITY_TYPE, name, new BlockEntityType<T>(factory, Set.of(validBlocks)).markAsVanilla()); // Fiddle - More data-driven - Block entities - mark as vanilla
      }
  
 -    private BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> factory, Set<Block> validBlocks) {

--- a/fiddle-server/minecraft-patches/sources/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
+++ b/fiddle-server/minecraft-patches/sources/net/minecraft/world/level/block/entity/BlockEntityType.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/level/block/entity/BlockEntityType.java
++++ b/net/minecraft/world/level/block/entity/BlockEntityType.java
+@@ -292,7 +_,7 @@
+         return Registry.register(BuiltInRegistries.BLOCK_ENTITY_TYPE, name, new BlockEntityType<>(factory, Set.of(validBlocks)));
+     }
+ 
+-    private BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> factory, Set<Block> validBlocks) {
++    public BlockEntityType(BlockEntityType.BlockEntitySupplier<? extends T> factory, Set<Block> validBlocks) { // Fiddle - More data-driven - Block entities - public
+         this.factory = factory;
+         this.validBlocks = validBlocks;
+     }
+@@ -320,7 +_,7 @@
+     }
+ 
+     @FunctionalInterface
+-    interface BlockEntitySupplier<T extends BlockEntity> {
++    public interface BlockEntitySupplier<T extends BlockEntity> { // Fiddle - More data-driven - Block entities - public
+         T create(BlockPos pos, BlockState state);
+     }
+ }

--- a/fiddle-server/paper-patches/files/src/main/java/io/papermc/paper/registry/PaperRegistries.java.patch
+++ b/fiddle-server/paper-patches/files/src/main/java/io/papermc/paper/registry/PaperRegistries.java.patch
@@ -1,6 +1,6 @@
 --- a/src/main/java/io/papermc/paper/registry/PaperRegistries.java
 +++ b/src/main/java/io/papermc/paper/registry/PaperRegistries.java
-@@ -110,8 +_,14 @@
+@@ -110,8 +_,15 @@
              start(Registries.GAME_EVENT, RegistryKey.GAME_EVENT).craft(GameEvent.class, CraftGameEvent::new).writable(PaperGameEventRegistryEntry.PaperBuilder::new),
              start(Registries.STRUCTURE_TYPE, RegistryKey.STRUCTURE_TYPE).craft(StructureType.class, CraftStructureType::new).build(),
              start(Registries.MOB_EFFECT, RegistryKey.MOB_EFFECT).craft(PotionEffectType.class, CraftPotionEffectType::new).build(),
@@ -13,6 +13,7 @@
 +            // Fiddle start - More data-driven - Paper registry API - Implementation part - Make writable and delayed
 +            start(Registries.BLOCK, RegistryKey.BLOCK).craft(BlockType.class, CraftBlockType::new).writable(org.fiddlemc.fiddle.impl.moredatadriven.paper.registry.BlockRegistryEntryImpl.BuilderImpl::new).delayed(),
 +            start(Registries.ITEM, RegistryKey.ITEM).craft(ItemType.class, CraftItemType::new).writable(org.fiddlemc.fiddle.impl.moredatadriven.paper.registry.ItemRegistryEntryImpl.BuilderImpl::new).delayed(),
++            start(Registries.BLOCK_ENTITY_TYPE, RegistryKey.BLOCK_ENTITY_TYPE).craft(org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.BlockEntityType.class, org.fiddlemc.fiddle.impl.moredatadriven.paper.registry.type.BlockEntityTypeImpl::of).writable(org.fiddlemc.fiddle.impl.moredatadriven.paper.registry.type.BlockEntityTypeRegistryEntryImpl.BuilderImpl::new).delayed(),
 +            // Fiddle end - More data-driven - Paper registry API - Implementation part - Make writable and delayed
              start(Registries.VILLAGER_PROFESSION, RegistryKey.VILLAGER_PROFESSION).craft(Villager.Profession.class, CraftVillager.CraftProfession::new).build(),
              start(Registries.VILLAGER_TYPE, RegistryKey.VILLAGER_TYPE).craft(Villager.Type.class, CraftVillager.CraftType::new).build(),

--- a/fiddle-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java.patch
+++ b/fiddle-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java.patch
@@ -1,0 +1,10 @@
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
+@@ -219,6 +_,7 @@
+ 
+     @Nullable
+     public Packet<ClientGamePacketListener> getUpdatePacket(@NotNull Location location) {
++        if (!this.snapshot.getType().isVanilla()) return null; // Fiddle - More data-driven - Block entities - Don't send non-vanilla block entities to the client
+         return new ClientboundBlockEntityDataPacket(CraftLocation.toBlockPosition(location), this.snapshot.getType(), this.getUpdateNBT());
+     }
+ 

--- a/fiddle-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java.patch
+++ b/fiddle-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java.patch
@@ -1,0 +1,10 @@
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockStates.java
+@@ -72,6 +_,7 @@
+     private static final BlockStateFactory<?> DEFAULT_FACTORY = new BlockStateFactory<>(CraftBlockState.class) {
+         @Override
+         public CraftBlockState createBlockState(World world, BlockPos pos, net.minecraft.world.level.block.state.BlockState state, BlockEntity blockEntity) {
++            if (blockEntity != null && !blockEntity.getType().isVanilla()) return new CraftBlockState(world, pos, state); // Fiddle - More data-driven - Block entities - TODO provide API so that plugins can read data from custom block entities using the API. For now, return a generic CraftBlockState instead of erroring.
+             // Paper - revert upstream's revert of the block state changes. Block entities that have already had the block type set to AIR are still valid, upstream decided to ignore them
+             Preconditions.checkState(blockEntity == null, "Unexpected BlockState for %s", CraftBlockType.minecraftToBukkit(state.getBlock()));
+             return new CraftBlockState(world, pos, state);

--- a/fiddle-server/src/main/java/org/fiddlemc/fiddle/api/moredatadriven/paper/registry/type/nms/BlockEntityTypeRegistryEntryBuilderNMS.java
+++ b/fiddle-server/src/main/java/org/fiddlemc/fiddle/api/moredatadriven/paper/registry/type/nms/BlockEntityTypeRegistryEntryBuilderNMS.java
@@ -1,0 +1,11 @@
+package org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.nms;
+
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.BlockEntityTypeRegistryEntry;
+
+public interface BlockEntityTypeRegistryEntryBuilderNMS extends BlockEntityTypeRegistryEntry.Builder {
+    BlockEntityTypeRegistryEntryBuilderNMS factorNMS(BlockEntityType.BlockEntitySupplier<?> factory);
+
+    BlockEntityTypeRegistryEntryBuilderNMS validBlocksNMS(Block... blocks);
+}

--- a/fiddle-server/src/main/java/org/fiddlemc/fiddle/impl/moredatadriven/paper/registry/ItemRegistryEntryImpl.java
+++ b/fiddle-server/src/main/java/org/fiddlemc/fiddle/impl/moredatadriven/paper/registry/ItemRegistryEntryImpl.java
@@ -185,7 +185,7 @@ public abstract class ItemRegistryEntryImpl implements ItemRegistryEntry, Settab
 
         @Override
         public ItemRegistryEntryImpl.BuilderImpl factoryForBlockNMS(Identifier blockIdentifier) {
-            return this.factoryForBlockNMS(blockIdentifier);
+            return this.factoryNMS(properties -> new BlockItem(BlockRegistry.get().getValue(blockIdentifier), properties));
         }
 
         @Override

--- a/fiddle-server/src/main/java/org/fiddlemc/fiddle/impl/moredatadriven/paper/registry/type/BlockEntityTypeImpl.java
+++ b/fiddle-server/src/main/java/org/fiddlemc/fiddle/impl/moredatadriven/paper/registry/type/BlockEntityTypeImpl.java
@@ -1,0 +1,16 @@
+package org.fiddlemc.fiddle.impl.moredatadriven.paper.registry.type;
+
+import io.papermc.paper.registry.HolderableBase;
+import net.minecraft.core.Holder;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+
+public class BlockEntityTypeImpl extends HolderableBase<BlockEntityType<?>> implements org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.BlockEntityType {
+
+    protected BlockEntityTypeImpl(final Holder<BlockEntityType<?>> holder) {
+        super(holder);
+    }
+
+    public static BlockEntityTypeImpl of(Holder<BlockEntityType<?>> holder) {
+        return new BlockEntityTypeImpl(holder);
+    }
+}

--- a/fiddle-server/src/main/java/org/fiddlemc/fiddle/impl/moredatadriven/paper/registry/type/BlockEntityTypeRegistryEntryImpl.java
+++ b/fiddle-server/src/main/java/org/fiddlemc/fiddle/impl/moredatadriven/paper/registry/type/BlockEntityTypeRegistryEntryImpl.java
@@ -1,0 +1,48 @@
+package org.fiddlemc.fiddle.impl.moredatadriven.paper.registry.type;
+
+import io.papermc.paper.registry.PaperRegistryBuilder;
+import io.papermc.paper.registry.data.util.Conversions;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntityType;
+import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.nms.BlockEntityTypeRegistryEntryBuilderNMS;
+import org.jspecify.annotations.Nullable;
+import java.util.HashSet;
+import java.util.Set;
+
+public class BlockEntityTypeRegistryEntryImpl {
+    protected @Nullable BlockEntityType<?> internal;
+
+    public BlockEntityTypeRegistryEntryImpl(
+        Conversions conversions,
+        @Nullable BlockEntityType<?> internal
+    ) {
+        this.internal = internal;
+    }
+
+    public static final class BuilderImpl implements BlockEntityTypeRegistryEntryBuilderNMS, PaperRegistryBuilder<net.minecraft.world.level.block.entity.BlockEntityType<?>, org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.BlockEntityType> {
+        private BlockEntityType.@Nullable BlockEntitySupplier<?> factory;
+        private final Set<Block> validBlocks = new HashSet<>();
+
+        public BuilderImpl(Conversions conversions, @Nullable BlockEntityType<?> internal) {}
+
+        @Override
+        public BlockEntityTypeRegistryEntryBuilderNMS factorNMS(BlockEntityType.BlockEntitySupplier<?> factory) {
+            this.factory = factory;
+            return this;
+        }
+
+        @Override
+        public BlockEntityTypeRegistryEntryBuilderNMS validBlocksNMS(final Block... blocks) {
+            this.validBlocks.addAll(Set.of(blocks));
+            return this;
+        }
+
+        @Override
+        public BlockEntityType<?> build() {
+            if (this.factory == null) {
+                throw new IllegalStateException("Factory must be set before building a BlockEntityType.");
+            }
+            return new BlockEntityType<>(this.factory, this.validBlocks);
+        }
+    }
+}

--- a/fiddle-server/src/main/java/org/fiddlemc/fiddle/impl/moredatadriven/paper/registry/type/BlockEntityTypeRegistryEntryImpl.java
+++ b/fiddle-server/src/main/java/org/fiddlemc/fiddle/impl/moredatadriven/paper/registry/type/BlockEntityTypeRegistryEntryImpl.java
@@ -4,8 +4,12 @@ import io.papermc.paper.registry.PaperRegistryBuilder;
 import io.papermc.paper.registry.data.util.Conversions;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.entity.BlockEntityType;
+import org.bukkit.block.BlockType;
+import org.bukkit.craftbukkit.block.CraftBlockType;
+import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.BlockEntityTypeRegistryEntry;
 import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.nms.BlockEntityTypeRegistryEntryBuilderNMS;
 import org.jspecify.annotations.Nullable;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -34,6 +38,12 @@ public class BlockEntityTypeRegistryEntryImpl {
         @Override
         public BlockEntityTypeRegistryEntryBuilderNMS validBlocksNMS(final Block... blocks) {
             this.validBlocks.addAll(Set.of(blocks));
+            return this;
+        }
+
+        @Override
+        public BlockEntityTypeRegistryEntry.Builder validBlocks(final BlockType... blocks) {
+            Arrays.stream(blocks).map(CraftBlockType::bukkitToMinecraftNew).forEach(this.validBlocks::add);
             return this;
         }
 

--- a/test-plugin/build.gradle.kts
+++ b/test-plugin/build.gradle.kts
@@ -2,8 +2,8 @@ version = "1.0.0-SNAPSHOT"
 
 // Uncomment the lines below to include the dev bundle
 // (after having published it by calling the script at gradle-bin/refreshTestPluginDevBundle)
-// plugins { id("io.papermc.paperweight.userdev") version "2.0.0-beta.19" }
-// dependencies { paperweight.paperDevBundle("1.21.11-R0.1-SNAPSHOT", "org.fiddlemc.fiddle") }
+plugins { id("io.papermc.paperweight.userdev") version "2.0.0-beta.19" }
+dependencies { paperweight.paperDevBundle("1.21.11-R0.1-SNAPSHOT", "org.fiddlemc.fiddle") }
 
 repositories {
     mavenLocal()

--- a/test-plugin/src/main/java/org/fiddlemc/testplugin/TestBlock.java
+++ b/test-plugin/src/main/java/org/fiddlemc/testplugin/TestBlock.java
@@ -1,0 +1,40 @@
+package org.fiddlemc.testplugin;
+
+import com.mojang.serialization.MapCodec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.BaseEntityBlock;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.BlockHitResult;
+import org.jspecify.annotations.Nullable;
+
+public class TestBlock extends BaseEntityBlock {
+
+    protected TestBlock(final Properties properties) {
+        super(properties);
+    }
+
+    @Override
+    protected MapCodec<? extends BaseEntityBlock> codec() {
+        return simpleCodec(TestBlock::new);
+    }
+
+    @Override
+    public @Nullable BlockEntity newBlockEntity(final BlockPos blockPos, final BlockState blockState) {
+        return new TestBlockEntity(blockPos, blockState);
+    }
+
+    @Override
+    protected InteractionResult useWithoutItem(final BlockState state, final Level level, final BlockPos pos, final Player player, final BlockHitResult hitResult) {
+        BlockEntity blockEntity = level.getBlockEntity(pos);
+        if (blockEntity instanceof TestBlockEntity testBlockEntity) {
+            testBlockEntity.incrementCount();
+            player.displayClientMessage(Component.literal("Count: " + testBlockEntity.getCount()), false);
+        }
+        return InteractionResult.SUCCESS_SERVER;
+    }
+}

--- a/test-plugin/src/main/java/org/fiddlemc/testplugin/TestBlockEntity.java
+++ b/test-plugin/src/main/java/org/fiddlemc/testplugin/TestBlockEntity.java
@@ -1,0 +1,39 @@
+package org.fiddlemc.testplugin;
+
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
+import java.util.Objects;
+
+public class TestBlockEntity extends BlockEntity {
+    private int count;
+
+    public TestBlockEntity(final BlockPos pos, final BlockState blockState) {
+        super(Objects.requireNonNull(BuiltInRegistries.BLOCK_ENTITY_TYPE.getValue(Identifier.fromNamespaceAndPath("example", "block_entity"))), pos, blockState);
+    }
+
+    @Override
+    protected void saveAdditional(final ValueOutput output) {
+        super.saveAdditional(output);
+        output.putInt("count", this.count);
+    }
+
+    @Override
+    protected void loadAdditional(final ValueInput input) {
+        super.loadAdditional(input);
+        this.count = input.getIntOr("count", 1);
+    }
+
+    public int getCount() {
+        return this.count;
+    }
+
+    public void incrementCount() {
+        this.count++;
+        this.setChanged();
+    }
+}

--- a/test-plugin/src/main/java/org/fiddlemc/testplugin/TestPluginBootstrap.java
+++ b/test-plugin/src/main/java/org/fiddlemc/testplugin/TestPluginBootstrap.java
@@ -154,7 +154,7 @@ public class TestPluginBootstrap implements PluginBootstrap {
                 builder -> {
                     var builderNMS = (BlockEntityTypeRegistryEntryBuilderNMS) builder;
                     builderNMS.factorNMS(TestBlockEntity::new);
-                    builderNMS.validBlocksNMS(BuiltInRegistries.BLOCK.get(Identifier.fromNamespaceAndPath("example", "block_entity")).get().value());
+                    builderNMS.validBlocks(PluginBlockTypes.EXAMPLE_BLOCK_ENTITY.get());
                 }
             );
         });

--- a/test-plugin/src/main/java/org/fiddlemc/testplugin/TestPluginBootstrap.java
+++ b/test-plugin/src/main/java/org/fiddlemc/testplugin/TestPluginBootstrap.java
@@ -3,9 +3,14 @@ package org.fiddlemc.testplugin;
 import io.papermc.paper.plugin.bootstrap.BootstrapContext;
 import io.papermc.paper.plugin.bootstrap.PluginBootstrap;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.TypedKey;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.Style;
+import net.minecraft.core.registries.BuiltInRegistries;
+import net.minecraft.resources.Identifier;
 import org.bukkit.Instrument;
 import org.bukkit.NamespacedKey;
 import org.bukkit.Note;
@@ -20,6 +25,8 @@ import org.bukkit.inventory.ItemType;
 import org.bukkit.inventory.meta.BlockDataMeta;
 import org.fiddlemc.fiddle.api.FiddleEvents;
 import org.fiddlemc.fiddle.api.clientview.ClientView;
+import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.nms.BlockRegistryEntryBuilderNMS;
+import org.fiddlemc.fiddle.api.moredatadriven.paper.registry.type.nms.BlockEntityTypeRegistryEntryBuilderNMS;
 import org.fiddlemc.fiddle.api.packetmapping.component.translatable.ServerSideTranslations;
 import org.fiddlemc.fiddle.api.packetmapping.item.ItemMappingUtilities;
 import org.fiddlemc.testplugin.data.PluginBlockTypes;
@@ -38,6 +45,7 @@ public class TestPluginBootstrap implements PluginBootstrap {
     @Override
     public void bootstrap(@NotNull BootstrapContext context) {
         loadIncludedDataPack(context);
+        registerBlockEntities(context);
         setBlockMappings(context);
         setItemMappings(context);
         setItemSourceTooltipMapping(context);
@@ -111,6 +119,63 @@ public class TestPluginBootstrap implements PluginBootstrap {
         state.setInstrument(Instrument.BELL);
         state.setNote(Note.natural(0, Note.Tone.G));
         return state;
+    }
+
+    /**
+     * Register custom block entities.
+     */
+    private void registerBlockEntities(@NotNull BootstrapContext context) {
+
+        context.getLifecycleManager().registerEventHandler(FiddleEvents.BLOCK, event -> {
+            System.out.println("FiddleEvents.BLOCK");
+            event.registry().register(
+                TypedKey.create(RegistryKey.BLOCK, Key.key("example:block_entity")),
+                builder -> {
+                    var builderNMS = (BlockRegistryEntryBuilderNMS) builder;
+                    builderNMS.factoryNMS(TestBlock::new);
+                }
+            );
+        });
+
+        context.getLifecycleManager().registerEventHandler(FiddleEvents.ITEM, event -> {
+            System.out.println("FiddleEvents.ITEM");
+            event.registry().register(
+                TypedKey.create(RegistryKey.ITEM, Key.key("example:block_entity")),
+                builder -> {
+                    builder.inheritsFromBlock(new NamespacedKey("example", "block_entity"));
+                }
+            );
+        });
+
+        context.getLifecycleManager().registerEventHandler(FiddleEvents.BLOCK_ENTITY_TYPE, event -> {
+            System.out.println("FiddleEvents.BLOCK_ENTITY_TYPE");
+            event.registry().register(
+                TypedKey.create(RegistryKey.BLOCK_ENTITY_TYPE, Key.key("example:block_entity")),
+                builder -> {
+                    var builderNMS = (BlockEntityTypeRegistryEntryBuilderNMS) builder;
+                    builderNMS.factorNMS(TestBlockEntity::new);
+                    builderNMS.validBlocksNMS(BuiltInRegistries.BLOCK.get(Identifier.fromNamespaceAndPath("example", "block_entity")).get().value());
+                }
+            );
+        });
+
+        context.getLifecycleManager().registerEventHandler(FiddleEvents.ITEM_MAPPING, event -> {
+            event.register(builder -> {
+                builder.everyAwarenessLevel();
+                builder.from(PluginItemTypes.EXAMPLE_BLOCK_ENTITY.get());
+                builder.to(handle -> {
+                    ItemMappingUtilities.get().setItemTypeWhilePreservingRest(handle, ItemType.DIAMOND_BLOCK);
+                });
+            });
+        });
+
+        context.getLifecycleManager().registerEventHandler(FiddleEvents.BLOCK_MAPPING, event -> {
+            event.register(builder -> {
+                builder.everyAwarenessLevel();
+                builder.fromEveryStateOf(PluginBlockTypes.EXAMPLE_BLOCK_ENTITY.get());
+                builder.to(BlockType.DIAMOND_BLOCK.createBlockData());
+            });
+        });
     }
 
     /**
@@ -676,6 +741,7 @@ public class TestPluginBootstrap implements PluginBootstrap {
                         case "more_vanilla_shapes" -> "More Vanilla Shapes";
                         case "quark" -> "Quark";
                         case "minecraft", "fiddle" -> null;
+                        case "example" -> "Example";
                         default ->
                             throw new IllegalStateException("Unexpected value: " + handle.getOriginal().getType().key().namespace());
                     };

--- a/test-plugin/src/main/java/org/fiddlemc/testplugin/data/PluginBlockTypes.java
+++ b/test-plugin/src/main/java/org/fiddlemc/testplugin/data/PluginBlockTypes.java
@@ -25,6 +25,7 @@ public final class PluginBlockTypes {
     public static Supplier<BlockType> DIORITE_BRICK_SLAB = blockType("quark:diorite_brick_slab");
     public static Supplier<BlockType> DIORITE_BRICK_STAIRS = blockType("quark:diorite_brick_stairs");
     public static Supplier<BlockType> DIORITE_BRICKS = blockType("quark:diorite_bricks");
+    public static Supplier<BlockType> EXAMPLE_BLOCK_ENTITY = blockType("example:block_entity");
 
     private static Supplier<BlockType> blockType(String key) {
         return Suppliers.memoize(() -> Registry.BLOCK.get(Key.key(key)));

--- a/test-plugin/src/main/java/org/fiddlemc/testplugin/data/PluginItemTypes.java
+++ b/test-plugin/src/main/java/org/fiddlemc/testplugin/data/PluginItemTypes.java
@@ -26,6 +26,7 @@ public final class PluginItemTypes {
     public static Supplier<ItemType> DIORITE_BRICK_STAIRS = itemType("quark:diorite_brick_stairs");
     public static Supplier<ItemType> DIORITE_BRICKS = itemType("quark:diorite_bricks");
     public static Supplier<ItemType> GLASS_SHARD = itemType("quark:glass_shard");
+    public static Supplier<ItemType> EXAMPLE_BLOCK_ENTITY = itemType("example:block_entity");
 
     private static Supplier<ItemType> itemType(String key) {
         return Suppliers.memoize(() -> Registry.ITEM.get(Key.key(key)));


### PR DESCRIPTION
Adds the ability to register custom block entity types that can be used to make custom block entities. Currently, this is only doable using NMS. A next step would be to add a way to do this using the API, which I'm thinking can be a separate PR.

Translating to the client is straightforward since the client does not need to know which blocks are block entities, so the packets are skipped.